### PR TITLE
RedStone payload serialization for tests

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -16,11 +16,11 @@
     "gas-named-return-values": "error",
     "gas-small-strings": "error",
     "gas-strict-inequalities": "error",
-    "gas-struct-packing": "error",
+    "gas-struct-packing": "warn",
     "interface-starts-with-i": "error",
     "max-line-length": ["error", 120],
     "ordering": "error",
-    "named-parameters-mapping": "error",
+    "named-parameters-mapping": "warn",
     "modifier-name-mixedcase": "error",
     "private-vars-leading-underscore": ["error", { "strict": false }],
     "reason-string": ["error", { "maxLength": 64 }]

--- a/.solhint.test.json
+++ b/.solhint.test.json
@@ -1,0 +1,27 @@
+{
+  "extends": "solhint:recommended",
+  "plugins": ["prettier"],
+  "rules": {
+    "one-contract-per-file": "off",
+    "code-complexity": ["error", 8],
+    "compiler-version": ["error", ">=0.5.13"],
+    "func-visibility": ["error", { "ignoreConstructors": true }],
+    "max-line-length": ["error", 120],
+    "not-rely-on-time": "off",
+    "function-max-lines": ["error", 120],
+    "max-states-count": "off",
+    "var-name-mixedcase": "off",
+    "func-name-mixedcase": "error",
+    "state-visibility": "off",
+    "const-name-snakecase": "off",
+    "contract-name-camelcase": "off",
+    "no-empty-blocks": "off",
+    "prettier/prettier": [
+      "error",
+      {
+        "endOfLine": "auto"
+      }
+    ],
+    "reason-string": ["warn", { "maxLength": 64 }]
+  }
+}

--- a/.solhint.test.json
+++ b/.solhint.test.json
@@ -3,6 +3,7 @@
   "plugins": ["prettier"],
   "rules": {
     "one-contract-per-file": "off",
+    "no-unused-vars": "off",
     "code-complexity": ["error", 8],
     "compiler-version": ["error", ">=0.5.13"],
     "func-visibility": ["error", { "ignoreConstructors": true }],

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,6 +1,6 @@
 export default {
   "*.md": ["prettier --write"],
-  "*.sol": ["prettier --write", "solhint -w 0"],
+  // "*.sol": ["prettier --write", "solhint -w 0"],
   "*.json": ["prettier --write"],
   "*.yml": ["prettier --write"],
 };

--- a/lint-staged.config.mjs
+++ b/lint-staged.config.mjs
@@ -1,6 +1,6 @@
 export default {
   "*.md": ["prettier --write"],
-  // "*.sol": ["prettier --write", "solhint -w 0"],
+  "*.sol": ["prettier --write", "solhint -w 0"],
   "*.json": ["prettier --write"],
   "*.yml": ["prettier --write"],
 };

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "format": "prettier --write \"**/*.{js,mjs,json,md,sol,yml}\" --list-different",
     "format:check": "prettier --check \"**/*.{js,mjs,json,md,sol,yml}\"",
-    "lint": "solhint \"{src,test,script}/**/*.sol\" -w 0",
+    "lint": "solhint \"{src,script}/**/*.sol\" -w 0 && solhint \"test/**/*.sol\" -c .solhint.test.json -w 0",
     "build": "forge build",
     "test": "forge test",
     "prepare": "husky"

--- a/src/Oracles.sol
+++ b/src/Oracles.sol
@@ -4,6 +4,8 @@ pragma solidity ^0.8.24;
 import {IOracles} from "./interfaces/IOracles.sol";
 import {OracleValue, OracleValueLib} from "./lib/OracleValueLib.sol";
 
+// TODO: reanable some/all of these once code written
+// solhint-disable no-empty-blocks, gas-struct-packing, named-parameters-mapping
 contract Oracles is IOracles {
     using OracleValueLib for OracleValue;
 

--- a/src/Oracles.sol
+++ b/src/Oracles.sol
@@ -26,7 +26,8 @@ contract Oracles is IOracles {
         uint16 allowedStaleness;
     }
 
-    mapping(address => OracleBuffer) rateFeeds;
+    mapping(address => OracleBuffer) public rateFeeds;
+
     function report(address rateFeedId) external {}
 
     function markStale(address rateFeedId) external {}

--- a/src/OraclesV2.sol
+++ b/src/OraclesV2.sol
@@ -8,6 +8,7 @@ import {OracleValueLib, OracleValue} from "./lib/OracleValueLib.sol";
 // solhint-disable-next-line max-line-length
 // Alex's original Oracles PoC: https://github.com/redstone-finance/redstone-evm-examples/blob/mento-v2-oracles-poc/contracts/mento-v2-oracles/MentoV2Oracles.sol
 
+// solhint-disable gas-struct-packing
 contract OraclesV2 is RedstoneConsumerNumericBase {
     using OracleValueLib for OracleValue;
 

--- a/test/RedStonePayload.t.sol
+++ b/test/RedStonePayload.t.sol
@@ -9,8 +9,7 @@ contract OraclesTest is Test {
     function setUp() public virtual {}
 
     function test_makePayload() public {
-        bytes memory dataFeedId = new bytes(20);
-        dataFeedId = "USDCELO";
+        bytes32 dataFeedId = "USDCELO";
         uint256[] memory values = new uint256[](1);
         bytes32[] memory rs = new bytes32[](1);
         bytes32[] memory ss = new bytes32[](1);
@@ -40,8 +39,7 @@ contract OraclesTest is Test {
     }
 
     function test_serializePayload() public {
-        bytes memory dataFeedId = new bytes(20);
-        dataFeedId = "USDCELO";
+        bytes32 dataFeedId = "USDCELO";
         uint256[] memory values = new uint256[](1);
         bytes32[] memory rs = new bytes32[](1);
         bytes32[] memory ss = new bytes32[](1);

--- a/test/RedStonePayload.t.sol
+++ b/test/RedStonePayload.t.sol
@@ -5,9 +5,9 @@ pragma solidity ^0.8.24;
 import {Test} from "forge-std/Test.sol";
 import {RedStonePayload} from "./lib/RedStonePayload.sol";
 
-contract RedStonePayloadTest is Test {
-    function setUp() public virtual {}
+contract RedStonePayloadTest is Test {}
 
+contract RedStonePayloadTest_makePayload is RedStonePayloadTest {
     function test_makePayload() public {
         bytes32 dataFeedId = "USDCELO";
         uint256[] memory values = new uint256[](1);
@@ -37,7 +37,9 @@ contract RedStonePayloadTest is Test {
             1337
         );
     }
+}
 
+contract RedStonePayload_serializePayload is RedStonePayloadTest {
     function test_serializePayload() public {
         bytes32 dataFeedId = "USDCELO";
         uint256[] memory values = new uint256[](1);
@@ -62,6 +64,7 @@ contract RedStonePayloadTest is Test {
         );
 
         bytes memory result = RedStonePayload.serializePayload(payload);
+        // 156 comes from manual math verification of what the length should be.
         assertEq(result.length, 156);
     }
 }

--- a/test/RedStonePayload.t.sol
+++ b/test/RedStonePayload.t.sol
@@ -1,0 +1,41 @@
+// SPDX-License-Identifier: UNLICENSED
+// solhint-disable func-name-mixedcase, gas-strict-inequalities, ordering
+pragma solidity ^0.8.24;
+
+import {Test} from "forge-std/Test.sol";
+import {RedStonePayload} from "./lib/RedStonePayload.sol";
+
+contract OraclesTest is Test {
+    function setUp() public virtual {}
+
+    function test_makePayload() public {
+        bytes memory dataFeedId = new bytes(20);
+        dataFeedId = "USDCELO";
+        uint256[] memory values = new uint256[](1);
+        bytes32[] memory rs = new bytes32[](1);
+        bytes32[] memory ss = new bytes32[](1);
+        uint8[] memory vs = new uint8[](1);
+        uint256[] memory timestamps = new uint256[](1);
+
+        values[0] = 42;
+        rs[0] = 0;
+        ss[0] = 0;
+        vs[0] = 0;
+        timestamps[0] = 1337;
+
+        RedStonePayload.Payload memory payload = RedStonePayload.makePayload(
+            dataFeedId,
+            values,
+            rs,
+            ss,
+            vs,
+            timestamps
+        );
+
+        assertEq(payload.dataPackages[0].dataPackage.dataPoints[0].value, 42);
+        assertEq(
+            payload.dataPackages[0].dataPackage.timestampMilliseconds,
+            1337
+        );
+    }
+}

--- a/test/RedStonePayload.t.sol
+++ b/test/RedStonePayload.t.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.24;
 import {Test} from "forge-std/Test.sol";
 import {RedStonePayload} from "./lib/RedStonePayload.sol";
 
-contract OraclesTest is Test {
+contract RedStonePayloadTest is Test {
     function setUp() public virtual {}
 
     function test_makePayload() public {

--- a/test/RedStonePayload.t.sol
+++ b/test/RedStonePayload.t.sol
@@ -38,4 +38,32 @@ contract OraclesTest is Test {
             1337
         );
     }
+
+    function test_serializePayload() public {
+        bytes memory dataFeedId = new bytes(20);
+        dataFeedId = "USDCELO";
+        uint256[] memory values = new uint256[](1);
+        bytes32[] memory rs = new bytes32[](1);
+        bytes32[] memory ss = new bytes32[](1);
+        uint8[] memory vs = new uint8[](1);
+        uint256[] memory timestamps = new uint256[](1);
+
+        values[0] = 42;
+        rs[0] = 0;
+        ss[0] = 0;
+        vs[0] = 0;
+        timestamps[0] = 1337;
+
+        RedStonePayload.Payload memory payload = RedStonePayload.makePayload(
+            dataFeedId,
+            values,
+            rs,
+            ss,
+            vs,
+            timestamps
+        );
+
+        bytes memory result = RedStonePayload.serializePayload(payload);
+        assertEq(result.length, 156);
+    }
 }

--- a/test/lib/RedStonePayload.sol
+++ b/test/lib/RedStonePayload.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+pragma solidity ^0.8.24;
+
+/**
+ * @notice Implements serialization to a RedStone data payload.
+ * @dev Reference:
+ * https://github.com/redstone-finance/redstone-oracles-monorepo/tree/main/packages/protocol/src
+ */
+library RedStonePayload {
+    // Constants from
+    // https://github.com/redstone-finance/redstone-oracles-monorepo/blob/main/packages/protocol/src/common/redstone-constants.ts
+    // Number of bytes reserved to store timestamp
+    uint256 constant TIMESTAMP_BS = 6;
+
+    // Number of bytes reserved to store the number of data points
+    uint256 constant DATA_POINTS_COUNT_BS = 3;
+
+    // Number of bytes reserved to store datapoints byte size
+    uint256 constant DATA_POINT_VALUE_BYTE_SIZE_BS = 4;
+
+    // Default value byte size for numeric values
+    uint256 constant DEFAULT_NUM_VALUE_BS = 32;
+
+    // Default precision for numeric values
+    uint256 constant DEFAULT_NUM_VALUE_DECIMALS = 8;
+
+    // Number of bytes reserved for data packages count
+    uint256 constant DATA_PACKAGES_COUNT_BS = 2;
+
+    // Number of bytes reserved for unsigned metadata byte size
+    uint256 constant UNSIGNED_METADATA_BYTE_SIZE_BS = 3;
+
+    // RedStone marker, which will be appended in the end of each transaction
+    uint256 constant REDSTONE_MARKER = 0x000002ed57011e0000;
+
+    // Byte size of RedStone marker
+    // we subtract 1 because of the 0x prefix
+    uint256 constant REDSTONE_MARKER_BS = 9;
+
+    // Byte size of signatures
+    uint256 constant SIGNATURE_BS = 65;
+
+    // Byte size of data feed id
+    uint256 constant DATA_FEED_ID_BS = 32;
+
+    struct DataPoint {
+        bytes dataFeedId;
+        uint256 value;
+        uint256 decimals;
+        uint256 valueBytesSize;
+        // Memory structs cannot contain mappings. We likely don't need metadata
+        // for our purposes. If we do, can replace this with two arrays.
+        // mapping (string => bytes) metadata;
+    }
+
+    struct DataPackage {
+        DataPoint[] dataPoints;
+        uint256 timestampMilliseconds;
+    }
+
+    struct Signature {
+        bytes32 r;
+        bytes32 s;
+        uint8 v;
+    }
+
+    struct SignedDataPackage {
+        DataPackage dataPackage;
+        Signature signature;
+    }
+
+    struct Payload {
+        SignedDataPackage[] dataPackages;
+        string metadata;
+    }
+
+    function makePayload(
+        bytes memory dataFeedId,
+        uint256[] memory values,
+        bytes32[] memory rs,
+        bytes32[] memory ss,
+        uint8[] memory vs,
+        uint256[] memory timestamps
+    ) internal pure returns (Payload memory) {
+        Payload memory payload;
+
+        uint256 numberPackages = values.length;
+
+        payload.dataPackages = new SignedDataPackage[](numberPackages);
+
+        for (uint256 i = 0; i < numberPackages; i++) {
+            DataPoint[] memory dataPoints = new DataPoint[](1);
+
+            dataPoints[0] = DataPoint(
+                dataFeedId,
+                values[i],
+                18,
+                8
+            );
+
+            DataPackage memory dataPackage = DataPackage(
+                dataPoints,
+                timestamps[i]
+            );
+
+            Signature memory signature = Signature(rs[i], ss[i], vs[i]);
+
+            payload.dataPackages[i] = SignedDataPackage(dataPackage, signature);
+        }
+
+        return payload;
+    }
+
+    function serializePayload(Payload memory payload) internal pure returns (bytes memory) {
+    }
+}

--- a/test/lib/RedStonePayload.sol
+++ b/test/lib/RedStonePayload.sol
@@ -7,6 +7,11 @@ pragma solidity ^0.8.24;
  * https://github.com/redstone-finance/redstone-oracles-monorepo/tree/main/packages/protocol/src
  */
 library RedStonePayload {
+    struct SerializationBuffer {
+        bytes buffer;
+        uint256 currentIndex;
+    }
+
     // Constants from
     // solhint-disable-next-line max-line-length
     // https://github.com/redstone-finance/redstone-oracles-monorepo/blob/main/packages/protocol/src/common/redstone-constants.ts
@@ -49,7 +54,7 @@ library RedStonePayload {
     uint256 constant DATA_POINTS_PER_PACKAGE = 1;
 
     struct DataPoint {
-        bytes dataFeedId;
+        bytes32 dataFeedId;
         uint256 value;
         uint256 decimals;
         uint256 valueBytesSize;
@@ -80,7 +85,7 @@ library RedStonePayload {
     }
 
     function makePayload(
-        bytes memory dataFeedId,
+        bytes32 dataFeedId,
         uint256[] memory values,
         bytes32[] memory rs,
         bytes32[] memory ss,
@@ -95,31 +100,128 @@ library RedStonePayload {
 
         for (uint256 i = 0; i < numberPackages; i++) {
             DataPoint[] memory dataPoints = new DataPoint[](1);
-
-            dataPoints[0] = DataPoint(
-                dataFeedId,
-                values[i],
-                18,
-                8
-            );
-
+            dataPoints[0] = DataPoint(dataFeedId, values[i], 18, 8);
             DataPackage memory dataPackage = DataPackage(
                 dataPoints,
                 timestamps[i]
             );
-
             Signature memory signature = Signature(rs[i], ss[i], vs[i]);
-
             payload.dataPackages[i] = SignedDataPackage(dataPackage, signature);
         }
 
         return payload;
     }
 
-    function serializePayload(Payload memory payload) internal pure returns (bytes memory) {
+    function newSerializationBuffer(
+        uint256 length
+    ) internal pure returns (SerializationBuffer memory) {
+        bytes memory buffer = new bytes(length);
+        return SerializationBuffer(buffer, 0);
+    }
+
+    function writeBytes32(
+        SerializationBuffer memory buffer,
+        bytes32 data
+    ) internal pure {
+        for (uint256 i = 0; i < 32; i++) {
+            uint256 bufferIndex = buffer.currentIndex + i;
+            buffer.buffer[bufferIndex] = data[i];
+        }
+
+        buffer.currentIndex += 32;
+    }
+
+    function writeNumber(
+        SerializationBuffer memory buffer,
+        uint256 value,
+        uint256 bytesToWrite
+    ) internal pure {
+        // we write the number back-to-front, makes the logic simpler
+        for (int256 i = int256(bytesToWrite) - 1; i >= 0; i--) {
+            uint256 bufferIndex = buffer.currentIndex + uint256(i);
+            buffer.buffer[bufferIndex] = bytes1(uint8(value % 0x100)); // write the last byte
+            value = value / 0x100; // truncate last byte
+        }
+
+        buffer.currentIndex += bytesToWrite;
+    }
+
+    function writeUint256(
+        SerializationBuffer memory buffer,
+        uint256 value
+    ) internal pure {
+        writeNumber(buffer, value, 32);
+    }
+
+    function writeDataPoint(
+        SerializationBuffer memory buffer,
+        DataPoint memory dataPoint
+    ) internal pure {
+        writeBytes32(buffer, dataPoint.dataFeedId);
+        writeUint256(buffer, dataPoint.value);
+    }
+
+    function writeTimestamp(
+        SerializationBuffer memory buffer,
+        uint256 timestamp
+    ) internal pure {
+        writeNumber(buffer, timestamp, TIMESTAMP_BS);
+    }
+
+    function writeDataPointSize(
+        SerializationBuffer memory buffer
+    ) internal pure {
+        writeNumber(buffer, 32, DATA_POINT_VALUE_BYTE_SIZE_BS);
+    }
+
+    function writeDataPointNumber(
+        SerializationBuffer memory buffer,
+        uint256 number
+    ) internal pure {
+        writeNumber(buffer, number, DATA_POINTS_COUNT_BS);
+    }
+
+    function writeSignature(
+        SerializationBuffer memory buffer,
+        Signature memory signature
+    ) internal pure {
+        writeBytes32(buffer, signature.r);
+        writeBytes32(buffer, signature.s);
+        writeNumber(buffer, signature.v, 1);
+    }
+
+    function writeSignedDataPackage(
+        SerializationBuffer memory buffer,
+        SignedDataPackage memory signedDataPackage
+    ) internal pure {
+        DataPackage memory dataPackage = signedDataPackage.dataPackage;
+        for (uint256 i = 0; i < dataPackage.dataPoints.length; i++) {
+            writeDataPoint(buffer, dataPackage.dataPoints[i]);
+        }
+        writeTimestamp(buffer, dataPackage.timestampMilliseconds);
+        writeDataPointSize(buffer);
+        writeDataPointNumber(buffer, dataPackage.dataPoints.length);
+        writeSignature(buffer, signedDataPackage.signature);
+    }
+
+    function writeEmptyMetadata(
+        SerializationBuffer memory buffer
+    ) internal pure {
+        writeNumber(buffer, 0, UNSIGNED_METADATA_BYTE_SIZE_BS);
+    }
+
+    function writeRedStoneMarker(
+        SerializationBuffer memory buffer
+    ) internal pure {
+        writeNumber(buffer, REDSTONE_MARKER, REDSTONE_MARKER_BS);
+    }
+
+    function serializePayload(
+        Payload memory payload
+    ) internal pure returns (bytes memory) {
         uint256 numberDataPackages = payload.dataPackages.length;
-        uint256 serializedPayloadLength =
-            REDSTONE_MARKER_BS +
+        // solhint-disable prettier/prettier
+        uint256 serializedPayloadLength = REDSTONE_MARKER_BS +
             UNSIGNED_METADATA_BYTE_SIZE_BS + // + 0 for actual metadata in our case
             DATA_PACKAGES_COUNT_BS +
             numberDataPackages * (
@@ -127,14 +229,25 @@ library RedStonePayload {
                 DATA_POINTS_COUNT_BS +
                 DATA_POINT_VALUE_BYTE_SIZE_BS +
                 TIMESTAMP_BS +
-                DATA_POINTS_PER_PACKAGE * ( // this is always = 1 in our case
+                DATA_POINTS_PER_PACKAGE * (
                     DATA_FEED_ID_BS +
                     DEFAULT_NUM_VALUE_BS
                 )
             );
+        // solhint-enable prettier/prettier
 
-        bytes memory serializedPayload = new bytes(serializedPayloadLength);
+        SerializationBuffer memory buffer = newSerializationBuffer(
+            serializedPayloadLength
+        );
 
-        return serializedPayload;
+        for (uint256 i = 0; i < numberDataPackages; i++) {
+            writeSignedDataPackage(buffer, payload.dataPackages[i]);
+        }
+
+        writeNumber(buffer, numberDataPackages, DATA_PACKAGES_COUNT_BS);
+        writeEmptyMetadata(buffer);
+        writeRedStoneMarker(buffer);
+
+        return buffer.buffer;
     }
 }

--- a/test/lib/RedStonePayload.sol
+++ b/test/lib/RedStonePayload.sol
@@ -8,6 +8,7 @@ pragma solidity ^0.8.24;
  */
 library RedStonePayload {
     // Constants from
+    // solhint-disable-next-line max-line-length
     // https://github.com/redstone-finance/redstone-oracles-monorepo/blob/main/packages/protocol/src/common/redstone-constants.ts
     // Number of bytes reserved to store timestamp
     uint256 constant TIMESTAMP_BS = 6;

--- a/test/lib/RedStonePayload.sol
+++ b/test/lib/RedStonePayload.sol
@@ -43,6 +43,10 @@ library RedStonePayload {
     // Byte size of data feed id
     uint256 constant DATA_FEED_ID_BS = 32;
 
+    // RedStone allows a single oracle to report for multiple feeds in a single
+    // batch, but our model assumes each batch is for a single data feed.
+    uint256 constant DATA_POINTS_PER_PACKAGE = 1;
+
     struct DataPoint {
         bytes dataFeedId;
         uint256 value;
@@ -112,5 +116,24 @@ library RedStonePayload {
     }
 
     function serializePayload(Payload memory payload) internal pure returns (bytes memory) {
+        uint256 numberDataPackages = payload.dataPackages.length;
+        uint256 serializedPayloadLength =
+            REDSTONE_MARKER_BS +
+            UNSIGNED_METADATA_BYTE_SIZE_BS + // + 0 for actual metadata in our case
+            DATA_PACKAGES_COUNT_BS +
+            numberDataPackages * (
+                SIGNATURE_BS +
+                DATA_POINTS_COUNT_BS +
+                DATA_POINT_VALUE_BYTE_SIZE_BS +
+                TIMESTAMP_BS +
+                DATA_POINTS_PER_PACKAGE * ( // this is always = 1 in our case
+                    DATA_FEED_ID_BS +
+                    DEFAULT_NUM_VALUE_BS
+                )
+            );
+
+        bytes memory serializedPayload = new bytes(serializedPayloadLength);
+
+        return serializedPayload;
     }
 }


### PR DESCRIPTION
Implements creation and serialization (to `bytes`) of RedStone payloads. This will be necessary to fully test the `report` function.

### Additional changes

* Some linting modifications:
  * introduced a separate solhint config for test files, as forge tests follow different conventions
  * temporarily disabled some rules to get a WIP PR out with current progress

### TODO

* Better test that the serialization actually works correctly
* Reanable/consciously reconfigure linting rules.