### PR TITLE
Test payload serialization

### DIFF
--- a/test/Oracles.t.sol
+++ b/test/Oracles.t.sol
@@ -18,9 +18,10 @@ contract OraclesTest is Test {
     }
 }
 
-// solhint-disable-next-line max-line-length
+// solhint-disable max-line-length
 // Example for a Redstone calldata payload:
 // https://github.com/redstone-finance/redstone-near-connectors/blob/7bc02fc5421200b15da56c33c5c6130130b3ff8a/js/test/integration.test.ts#L17-L37
+// solhint-enable max-line-length
 contract Oracles_report is OraclesTest {}
 
 contract Oracles_markStale is OraclesTest {}

--- a/test/RedStonePayload.t.sol
+++ b/test/RedStonePayload.t.sol
@@ -5,10 +5,17 @@ pragma solidity ^0.8.24;
 import {Test} from "forge-std/Test.sol";
 import {RedStonePayload} from "./lib/RedStonePayload.sol";
 
-contract RedStonePayloadTest is Test {}
+contract RedStonePayloadTest is Test {
+    uint256 constant PRIVATE_KEY_1 =
+        0x1111111111111111111111111111111111111111111111111111111111111111;
+    address constant ADDRESS_1 = 0x19E7E376E7C213B7E7e7e46cc70A5dD086DAff2A;
+    uint256 constant PRIVATE_KEY_2 =
+        0x2222222222222222222222222222222222222222222222222222222222222222;
+    address constant ADDRESS_2 = 0x1563915e194D8CfBA1943570603F7606A3115508;
+}
 
 contract RedStonePayloadTest_makePayload is RedStonePayloadTest {
-    function test_makePayload() public pure {
+    function test_makePayloadWithSignatures() public pure {
         bytes32 dataFeedId = "USDCELO";
         uint256[] memory values = new uint256[](1);
         bytes32[] memory rs = new bytes32[](1);
@@ -28,6 +35,30 @@ contract RedStonePayloadTest_makePayload is RedStonePayloadTest {
             rs,
             ss,
             vs,
+            timestamps
+        );
+
+        assertEq(payload.dataPackages[0].dataPackage.dataPoints[0].value, 42);
+        assertEq(
+            payload.dataPackages[0].dataPackage.timestampMilliseconds,
+            1337
+        );
+    }
+
+    function test_makePayloadWithPrivateKeys() public pure {
+        bytes32 dataFeedId = "USDCELO";
+        uint256[] memory values = new uint256[](1);
+        uint256[] memory privateKeys = new uint256[](1);
+        uint256[] memory timestamps = new uint256[](1);
+
+        values[0] = 42;
+        privateKeys[0] = PRIVATE_KEY_1;
+        timestamps[0] = 1337;
+
+        RedStonePayload.Payload memory payload = RedStonePayload.makePayload(
+            dataFeedId,
+            values,
+            privateKeys,
             timestamps
         );
 

--- a/test/RedStonePayload.t.sol
+++ b/test/RedStonePayload.t.sol
@@ -12,6 +12,57 @@ contract RedStonePayloadTest is Test {
     uint256 constant PRIVATE_KEY_2 =
         0x2222222222222222222222222222222222222222222222222222222222222222;
     address constant ADDRESS_2 = 0x1563915e194D8CfBA1943570603F7606A3115508;
+
+    // The Solidity compiler does not support storing some more complex structs
+    // in storage, so we return example data packages from functions.
+    function payloadWithOneDataPackage()
+        internal
+        pure
+        returns (RedStonePayload.Payload memory)
+    {
+        bytes32 dataFeedId = "USDCELO";
+        uint256[] memory values = new uint256[](1);
+        uint256[] memory privateKeys = new uint256[](1);
+        uint256[] memory timestamps = new uint256[](1);
+
+        values[0] = 42;
+        privateKeys[0] = PRIVATE_KEY_1;
+        timestamps[0] = 1337;
+
+        return
+            RedStonePayload.makePayload(
+                dataFeedId,
+                values,
+                privateKeys,
+                timestamps
+            );
+    }
+
+    function payloadWithTwoDataPackages()
+        internal
+        pure
+        returns (RedStonePayload.Payload memory)
+    {
+        bytes32 dataFeedId = "USDCELO";
+        uint256[] memory values = new uint256[](2);
+        uint256[] memory privateKeys = new uint256[](2);
+        uint256[] memory timestamps = new uint256[](2);
+
+        values[0] = 42;
+        values[0] = 24;
+        privateKeys[0] = PRIVATE_KEY_1;
+        privateKeys[1] = PRIVATE_KEY_2;
+        timestamps[0] = 1337;
+        timestamps[1] = 1337;
+
+        return
+            RedStonePayload.makePayload(
+                dataFeedId,
+                values,
+                privateKeys,
+                timestamps
+            );
+    }
 }
 
 contract RedStonePayloadTest_makePayload is RedStonePayloadTest {
@@ -38,6 +89,15 @@ contract RedStonePayloadTest_makePayload is RedStonePayloadTest {
             timestamps
         );
 
+        assertEq(
+            payload.dataPackages[0].dataPackage.dataPoints[0].dataFeedId,
+            "USDCELO"
+        );
+        assertEq(payload.dataPackages[0].dataPackage.dataPoints[0].decimals, 8);
+        assertEq(
+            payload.dataPackages[0].dataPackage.dataPoints[0].valueBytesSize,
+            32
+        );
         assertEq(payload.dataPackages[0].dataPackage.dataPoints[0].value, 42);
         assertEq(
             payload.dataPackages[0].dataPackage.timestampMilliseconds,
@@ -63,6 +123,11 @@ contract RedStonePayloadTest_makePayload is RedStonePayloadTest {
         );
 
         assertEq(payload.dataPackages[0].dataPackage.dataPoints[0].value, 42);
+        assertEq(payload.dataPackages[0].dataPackage.dataPoints[0].decimals, 8);
+        assertEq(
+            payload.dataPackages[0].dataPackage.dataPoints[0].valueBytesSize,
+            32
+        );
         assertEq(
             payload.dataPackages[0].dataPackage.timestampMilliseconds,
             1337
@@ -71,31 +136,19 @@ contract RedStonePayloadTest_makePayload is RedStonePayloadTest {
 }
 
 contract RedStonePayload_serializePayload is RedStonePayloadTest {
-    function test_serializePayload() public pure {
-        bytes32 dataFeedId = "USDCELO";
-        uint256[] memory values = new uint256[](1);
-        bytes32[] memory rs = new bytes32[](1);
-        bytes32[] memory ss = new bytes32[](1);
-        uint8[] memory vs = new uint8[](1);
-        uint256[] memory timestamps = new uint256[](1);
-
-        values[0] = 42;
-        rs[0] = 0;
-        ss[0] = 0;
-        vs[0] = 0;
-        timestamps[0] = 1337;
-
-        RedStonePayload.Payload memory payload = RedStonePayload.makePayload(
-            dataFeedId,
-            values,
-            rs,
-            ss,
-            vs,
-            timestamps
-        );
+    function test_serializePayload_oneDataPackage() public pure {
+        RedStonePayload.Payload memory payload = payloadWithOneDataPackage();
 
         bytes memory result = RedStonePayload.serializePayload(payload);
         // 156 comes from manual math verification of what the length should be.
         assertEq(result.length, 156);
+    }
+
+    function test_serializePayload_twoDataPackages() public pure {
+        RedStonePayload.Payload memory payload = payloadWithTwoDataPackages();
+
+        bytes memory result = RedStonePayload.serializePayload(payload);
+        // 298 comes from manual math verification of what the length should be.
+        assertEq(result.length, 298);
     }
 }

--- a/test/lib/DebugRedStoneConsumer.sol
+++ b/test/lib/DebugRedStoneConsumer.sol
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: UNLICENSED
+// solhint-disable func-name-mixedcase, gas-strict-inequalities, ordering
+pragma solidity ^0.8.24;
+
+import {RedstoneConsumerNumericBase} from "redstone/contracts/core/RedstoneConsumerNumericBase.sol";
+
+contract DebugRedStoneConsumer is RedstoneConsumerNumericBase {
+    address constant ADDRESS_1 = 0x19E7E376E7C213B7E7e7e46cc70A5dD086DAff2A;
+    address constant ADDRESS_2 = 0x1563915e194D8CfBA1943570603F7606A3115508;
+    uint256[] public receivedValues;
+    uint256 public receivedTimestamp;
+    uint8 public signersThreshold;
+
+    function report(bytes32 rateFeedId) public returns (uint256) {
+        receivedTimestamp = extractTimestampsAndAssertAllAreEqual();
+        return getOracleNumericValueFromTxMsg(rateFeedId);
+    }
+
+    function getAuthorisedSignerIndex(address receivedSigner) public pure override returns (uint8) {
+        if (receivedSigner == ADDRESS_1) {
+            return 1;
+        } else if (receivedSigner == ADDRESS_2) {
+            return 2;
+        }
+    }
+
+    function setUniqueSignersThreshold(uint8 threshold) public {
+        signersThreshold = threshold;
+    }
+
+    function getUniqueSignersThreshold() public view override returns (uint8) {
+        return signersThreshold;
+    }
+
+    function aggregateValues(uint256[] memory values) public pure override returns (uint256) {
+        // VERY hacky way of returning up to 4 of the received uint64 values
+        // while keeping this function `view`.
+        uint256 result = 0;
+        for (uint256 i = 0; i < values.length && i < 4; i++) {
+            result <<= 64;
+            result |= values[i];
+        }
+        return result;
+    }
+
+    function parseAggregatedValue(
+        uint256 value
+    ) public pure returns (uint64[4] memory) {
+        uint64[4] memory values;
+        for (uint64 i = 0; i < 4; i++) {
+            values[i] = uint64(value % 2**64);
+            value >>= 64;
+        }
+        return values;
+    }
+}

--- a/test/lib/RedStonePayload.sol
+++ b/test/lib/RedStonePayload.sol
@@ -90,7 +90,10 @@ library RedStonePayload {
     // batch, but our model assumes each batch is for a single data feed.
     uint256 private constant DATA_POINTS_PER_PACKAGE = 1;
 
-    function signDataPackage(DataPackage memory dataPackage, uint256 privateKey) internal pure returns (Signature memory) {
+    function signDataPackage(
+        DataPackage memory dataPackage,
+        uint256 privateKey
+    ) internal pure returns (Signature memory) {
        uint256 dataPackageSerializedSize =
             DATA_POINTS_COUNT_BS +
             DATA_POINT_VALUE_BYTE_SIZE_BS +

--- a/test/lib/RedStonePayload.sol
+++ b/test/lib/RedStonePayload.sol
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.24;
 
+import {Vm} from "forge-std/Vm.sol";
+
 /**
  * @notice Implements serialization to a RedStone data payload.
  * @dev Reference:
  * https://github.com/redstone-finance/redstone-oracles-monorepo/tree/main/packages/protocol/src
  */
 library RedStonePayload {
+    // See https://book.getfoundry.sh/forge/cheatcodes
+    address private constant CHEATCODE_ADDRESS = 0x7109709ECfa91a80626fF3989D68f67F5b1DD12D;
+    Vm private constant vm = Vm(CHEATCODE_ADDRESS);
+
     struct SerializationBuffer {
         bytes buffer;
         uint256 currentIndex;
@@ -83,6 +89,49 @@ library RedStonePayload {
     // RedStone allows a single oracle to report for multiple feeds in a single
     // batch, but our model assumes each batch is for a single data feed.
     uint256 private constant DATA_POINTS_PER_PACKAGE = 1;
+
+    function signDataPackage(DataPackage memory dataPackage, uint256 privateKey) internal pure returns (Signature memory) {
+       uint256 dataPackageSerializedSize =
+            DATA_POINTS_COUNT_BS +
+            DATA_POINT_VALUE_BYTE_SIZE_BS +
+            TIMESTAMP_BS +
+            DATA_POINTS_PER_PACKAGE * (
+                DATA_FEED_ID_BS +
+                DEFAULT_NUM_VALUE_BS
+            );
+        SerializationBuffer memory buffer = newSerializationBuffer(dataPackageSerializedSize);
+        writeDataPackage(buffer, dataPackage);
+        bytes32 digest = keccak256(buffer.buffer);
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(privateKey, digest);
+        return Signature(r, s, v);
+    }
+
+    function makePayload(
+        bytes32 dataFeedId,
+        uint256[] memory values,
+        uint256[] memory privateKeys,
+        uint256[] memory timestamps
+    ) internal pure returns (Payload memory) {
+        Payload memory payload;
+
+        uint256 numberPackages = values.length;
+
+        payload.dataPackages = new SignedDataPackage[](numberPackages);
+
+        for (uint256 i = 0; i < numberPackages; i++) {
+            DataPoint[] memory dataPoints = new DataPoint[](1);
+            dataPoints[0] = DataPoint(dataFeedId, values[i], 18, 8);
+            DataPackage memory dataPackage = DataPackage(
+                dataPoints,
+                timestamps[i]
+            );
+
+            Signature memory signature = signDataPackage(dataPackage, privateKeys[i]);
+            payload.dataPackages[i] = SignedDataPackage(dataPackage, signature);
+        }
+
+        return payload;
+    }
 
     function makePayload(
         bytes32 dataFeedId,
@@ -190,17 +239,23 @@ library RedStonePayload {
         writeNumber(buffer, signature.v, 1);
     }
 
-    function writeSignedDataPackage(
+    function writeDataPackage(
         SerializationBuffer memory buffer,
-        SignedDataPackage memory signedDataPackage
+        DataPackage memory dataPackage
     ) internal pure {
-        DataPackage memory dataPackage = signedDataPackage.dataPackage;
         for (uint256 i = 0; i < dataPackage.dataPoints.length; i++) {
             writeDataPoint(buffer, dataPackage.dataPoints[i]);
         }
         writeTimestamp(buffer, dataPackage.timestampMilliseconds);
         writeDataPointSize(buffer);
         writeDataPointNumber(buffer, dataPackage.dataPoints.length);
+    }
+
+    function writeSignedDataPackage(
+        SerializationBuffer memory buffer,
+        SignedDataPackage memory signedDataPackage
+    ) internal pure {
+        writeDataPackage(buffer, signedDataPackage.dataPackage);
         writeSignature(buffer, signedDataPackage.signature);
     }
 

--- a/test/lib/RedStonePayload.sol
+++ b/test/lib/RedStonePayload.sol
@@ -106,6 +106,24 @@ library RedStonePayload {
         return Signature(r, s, v);
     }
 
+    function makeDataPackage(
+        bytes32 dataFeedId,
+        uint256 value,
+        uint256 timestamp
+    ) internal pure returns (DataPackage memory) {
+        DataPoint[] memory dataPoints = new DataPoint[](1);
+        dataPoints[0] = DataPoint(
+            dataFeedId,
+            value,
+            DEFAULT_NUM_VALUE_DECIMALS,
+            DEFAULT_NUM_VALUE_BS
+        );
+        return DataPackage(
+            dataPoints,
+            timestamp
+        );
+    }
+
     function makePayload(
         bytes32 dataFeedId,
         uint256[] memory values,
@@ -119,13 +137,11 @@ library RedStonePayload {
         payload.dataPackages = new SignedDataPackage[](numberPackages);
 
         for (uint256 i = 0; i < numberPackages; i++) {
-            DataPoint[] memory dataPoints = new DataPoint[](1);
-            dataPoints[0] = DataPoint(dataFeedId, values[i], 18, 8);
-            DataPackage memory dataPackage = DataPackage(
-                dataPoints,
+            DataPackage memory dataPackage = makeDataPackage(
+                dataFeedId,
+                values[i],
                 timestamps[i]
             );
-
             Signature memory signature = signDataPackage(dataPackage, privateKeys[i]);
             payload.dataPackages[i] = SignedDataPackage(dataPackage, signature);
         }
@@ -148,10 +164,9 @@ library RedStonePayload {
         payload.dataPackages = new SignedDataPackage[](numberPackages);
 
         for (uint256 i = 0; i < numberPackages; i++) {
-            DataPoint[] memory dataPoints = new DataPoint[](1);
-            dataPoints[0] = DataPoint(dataFeedId, values[i], 18, 8);
-            DataPackage memory dataPackage = DataPackage(
-                dataPoints,
+            DataPackage memory dataPackage = makeDataPackage(
+                dataFeedId,
+                values[i],
                 timestamps[i]
             );
             Signature memory signature = Signature(rs[i], ss[i], vs[i]);


### PR DESCRIPTION
* Added a few more conditions in existing payload tests.
* Added payload generation with private key rather than prepared signature.
* Added tests with two data packages.
* (most importantly) Added tests that pass the serialized payload to RedStone's deserializer, verify it deserializes correctly.

Two slight concerns that I noticed while going through the deserialization code:

* The `aggregateValues` hook has to be `view`. This is the only place where we have access to the array of values in a report batch. Initially I had thought this would have been the function where we implement most of our functionality, but we can't write to storage/call other contracts from here. We might be able to work around this by encoding aggregated data (specifically, `isWithinAllowedDeviation`, `isCertain`) in the return value of this function (it returns `uint256` while our rate feed values fit in `uint64`).
* The deserializer takes into account only `uniqueSignersThreshold` values. It won't bother passing more into `aggregateValues` if there's more in the batch. This could cause two problems:
  * Slightly reduces security, by forcing the Oracle to always operate at the minimum allowed number of operators taken into account.
  * Could bias the median, given we're expecting the list of values in a batch to be sorted (so values from one extreme will be cut off by this behavior).