### PR TITLE
Follow up to key concept renaming

### DIFF
--- a/src/Oracles.sol
+++ b/src/Oracles.sol
@@ -82,12 +82,6 @@ contract Oracles is IOracles, RedstoneConsumerNumericBase {
 
     address internal _currentlyUpdatedRateFeedId;
 
-    /**************************************/
-    /*                                    */
-    /*  RedStone Base Contract Overrides  */
-    /*                                    */
-    /**************************************/
-
     error InvalidProviderForRateFeed(address rateFeedId, address provider);
     error TimestampFromFutureIsNotAllowed(
         uint256 receivedTimestampMilliseconds,

--- a/src/Oracles.sol
+++ b/src/Oracles.sol
@@ -32,7 +32,7 @@ contract Oracles is IOracles, RedstoneConsumerNumericBase {
         uint8 priceWindowSize;
 
         /// @dev The maximal allowed deviation between reported prices within a batch, expressed as a factor < 1.
-        uint16 allowedDeviation;
+        uint16 allowedDeviationNumerator;
 
         /// @dev The minimal number of data providers that need to have reported a value in the last report.
         uint8 quorum;
@@ -128,9 +128,9 @@ contract Oracles is IOracles, RedstoneConsumerNumericBase {
         uint8 priceWindowSize
     ) external {}
 
-    function setAllowedDeviation(
+    function setAllowedDeviationNumerator(
         address rateFeedId,
-        uint16 allowedDeviation
+        uint16 allowedDeviationNumerator
     ) external {}
 
     function setQuorum(address rateFeedId, uint8 quorum) external {}
@@ -148,7 +148,7 @@ contract Oracles is IOracles, RedstoneConsumerNumericBase {
     function addRateFeed(
         address rateFeedId,
         uint8 priceWindowSize,
-        uint16 allowedDeviation,
+        uint16 allowedDeviationNumerator,
         uint8 quorum,
         uint8 certaintyThreshold,
         uint16 allowedStalenessInSeconds,
@@ -194,7 +194,7 @@ contract Oracles is IOracles, RedstoneConsumerNumericBase {
         view
         returns (
             uint8 priceWindowSize,
-            uint16 allowedDeviation,
+            uint16 allowedDeviationNumerator,
             uint8 quorum,
             uint8 certaintyThreshold,
             uint16 allowedStaleness
@@ -203,7 +203,7 @@ contract Oracles is IOracles, RedstoneConsumerNumericBase {
         RateFeedDetails memory details = _rateFeeds[rateFeedId].details;
         return (
             details.priceWindowSize,
-            details.allowedDeviation,
+            details.allowedDeviationNumerator,
             details.quorum,
             details.certaintyThreshold,
             details.allowedStaleness
@@ -290,7 +290,7 @@ contract Oracles is IOracles, RedstoneConsumerNumericBase {
             );
         }
 
-        if ((maxVal - minVal) > rateFeed.details.allowedDeviation) {
+        if ((maxVal - minVal) > rateFeed.details.allowedDeviationNumerator) {
             revert MinAndMaxValuesDeviateTooMuch(minVal, maxVal);
         }
 

--- a/src/interfaces/IOracles.sol
+++ b/src/interfaces/IOracles.sol
@@ -72,7 +72,7 @@ interface IOracles {
      * @notice Adds a new supported rate feed.
      * @param rateFeedId                The new rate feed's ID, calculated as, i.e.: `address(uint160(uint256(keccak256("CELOUSD"))))`
      * @param priceWindowSize           The number of most recent median prices to average over for the final reported price.
-     * @param allowedDeviation          The maximum allowed deviation between the lowest and highest price values in a price report
+     * @param allowedDeviationNumerator The maximum allowed deviation between the lowest and highest price values in a price report
      * @param quorum                    The minimum number of values per report.
      * @param certaintyThreshold        The minimum number of certain values per report.
      * @param allowedStalenessInSeconds The allowed staleness in seconds.
@@ -82,7 +82,7 @@ interface IOracles {
     function addRateFeed(
         address rateFeedId,
         uint8 priceWindowSize,
-        uint16 allowedDeviation,
+        uint16 allowedDeviationNumerator,
         uint8 quorum,
         uint8 certaintyThreshold,
         uint16 allowedStalenessInSeconds,
@@ -134,14 +134,16 @@ interface IOracles {
     /**
      * @notice Sets the allowed price deviation between the lowest and highest price values in a report for a rate feed.
      * @param rateFeedId The rate feed being configured.
-     * @param allowedDeviation The difference between the lowest and highest value in a price report.
-     *        Expressed as the numerator of a fraction over uint16.max (65535). I.e., if allowedDeviation was 10_000,
-     *        then the difference between price values can't be greater than 1_000 / 65_535 = 0.015259... ≈ 1.526%
+     * @param allowedDeviationNumerator Defines the allowed difference between the lowest and highest value in a price
+     *        report.
+     *        Expressed as the numerator of a fraction over uint16.max (65535). I.e., if allowedDeviationNumerator was
+     *        1_000, then the largest value in a batch can't be greater than the smallest value by more
+     *        than 1_000 / 65_535 = 0.015259... ≈ 1.526%.
      * @dev Only callable by the owner.
      */
-    function setAllowedDeviation(
+    function setAllowedDeviationNumerator(
         address rateFeedId,
-        uint16 allowedDeviation
+        uint16 allowedDeviationNumerator
     ) external;
 
     /**
@@ -204,7 +206,7 @@ interface IOracles {
      * @notice Returns the current configuration parameters for a rate feed.
      * @param rateFeedId The rate feed being queried.
      * @return priceWindowSize           The number of most recent median prices to average over for the final reported price.
-     * @return allowedDeviation          The maximum allowed deviation between the lowest and highest price values in a price report.
+     * @return allowedDeviationNumerator The maximum allowed deviation between the lowest and highest price values in a price report.
      * @return quorum                    The minimum number of values per report.
      * @return certaintyThreshold        The minimum number of certain values per report.
      * @return allowedStalenessInSeconds The allowed staleness in seconds.
@@ -216,7 +218,7 @@ interface IOracles {
         view
         returns (
             uint8 priceWindowSize,
-            uint16 allowedDeviation,
+            uint16 allowedDeviationNumerator,
             uint8 quorum,
             uint8 certaintyThreshold,
             uint16 allowedStalenessInSeconds

--- a/test/Oracles.t.sol
+++ b/test/Oracles.t.sol
@@ -62,13 +62,18 @@ contract Oracles_setPriceWindowSize is OraclesTest {
     */
 }
 
-contract Oracles_setAllowedDeviation is OraclesTest {
-    function testFuzz_setsAllowedDeviation(uint16 allowedDeviation) public {
-        oracles.setAllowedDeviation(aRateFeed, allowedDeviation);
-        (, uint16 realAllowedDeviation, , , ) = oracles.rateFeedConfig(
+contract Oracles_setAllowedDeviationNumerator is OraclesTest {
+    function testFuzz_setsAllowedDeviationNumerator(
+        uint16 allowedDeviationNumerator
+    ) public {
+        oracles.setAllowedDeviationNumerator(
+            aRateFeed,
+            allowedDeviationNumerator
+        );
+        (, uint16 realAllowedDeviationNumerator, , , ) = oracles.rateFeedConfig(
             aRateFeed
         );
-        assertEq(realAllowedDeviation, allowedDeviation);
+        assertEq(realAllowedDeviationNumerator, allowedDeviationNumerator);
     }
 
     /*
@@ -152,14 +157,14 @@ contract Oracles_addRateFeed is OraclesTest {
 
         (
             uint8 realWindowSize,
-            uint16 realAllowedDeviation,
+            uint16 realAllowedDeviationNumerator,
             uint8 realQuorum,
             uint8 realCertaintyThreshold,
             uint16 realAllowedStaleness
         ) = oracles.rateFeedConfig(anotherRateFeed);
 
         assertEq(realWindowSize, 2);
-        assertEq(realAllowedDeviation, 100);
+        assertEq(realAllowedDeviationNumerator, 100);
         assertEq(realQuorum, 5);
         assertEq(realCertaintyThreshold, 2);
         assertEq(realAllowedStaleness, 120);
@@ -183,7 +188,7 @@ contract Oracles_removeRateFeed is OraclesTest {
         oracles.addRateFeed({
             rateFeedId: _anotherRateFeed,
             priceWindowSize: 2,
-            allowedDeviation: 100,
+            allowedDeviationNumerator: 100,
             quorum: 5,
             certaintyThreshold: 3,
             allowedStalenessInSeconds: 120,

--- a/test/Oracles.t.sol
+++ b/test/Oracles.t.sol
@@ -18,9 +18,10 @@ contract OraclesTest is Test {
     }
 }
 
-// solhint-disable-next-line max-line-length
+// solhint-disable max-line-length
 // Example for a Redstone calldata payload:
 // https://github.com/redstone-finance/redstone-near-connectors/blob/7bc02fc5421200b15da56c33c5c6130130b3ff8a/js/test/integration.test.ts#L17-L37
+// solhint-enable max-line-length
 contract Oracles_report is OraclesTest {}
 
 contract Oracles_markStale is OraclesTest {}


### PR DESCRIPTION
This is a follow up to #4 after @chapati23's comments.

* Removes an erroneous heading comment
* Renames `allowedDeviation` to `allowedDeviationNumerator`
* Specifies the behavior of `allowedDeviationNumerator` according to the discussion [here](https://github.com/mento-protocol/oracle-v2-playground/pull/4#discussion_r1599818229).